### PR TITLE
Embed Google Maps iframes for parking locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
     .row{display:grid;grid-template-columns:1fr 1fr;gap:44px;align-items:center;margin-bottom:64px}
     @media(max-width:900px){.row{grid-template-columns:1fr;text-align:center}}
 
+    .map-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:28px;margin-top:32px}
+    .map-grid iframe{width:100%;height:280px;border:0;border-radius:var(--r-lg);box-shadow:var(--shadow)}
+    @media(max-width:1100px){.map-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    @media(max-width:700px){.map-grid{grid-template-columns:1fr}}
+
     /* Subtle section divider like Squarespace */
     main > section:not(:first-child){border-top:1px solid var(--line)}
     main > section > h2{position:relative;padding-top:26px}
@@ -115,9 +120,11 @@
       <h2>Parcheggi</h2>
       <div class="card">
         <p>Ecco i parcheggi più comodi per la chiesa:</p>
-        <p><a target="_blank" href="https://maps.app.goo.gl/c7kDXMc5uR92ogPw6?g_st=aw">Mappa generale ↗</a></p>
-        <p><a target="_blank" href="https://maps.app.goo.gl/DkFLCp6Mf2wqPwND8?g_st=aw">Parcheggio Piazza Cavour ↗</a></p>
-        <p><a target="_blank" href="https://maps.app.goo.gl/P6af4Sk8ebfu78jq5?g_st=aw">Parcheggio Piazza Mercato ↗</a></p>
+      </div>
+      <div class="map-grid">
+        <iframe src="https://www.google.com/maps?q=Basilica+Santa+Maria+Nuova,+Via+Giuseppe+Borsani,+Abbiategrasso&output=embed" title="Mappa generale - Basilica Santa Maria Nuova" loading="lazy" allowfullscreen="" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        <iframe src="https://www.google.com/maps?q=Piazza+Cavour,+Abbiategrasso&output=embed" title="Parcheggio Piazza Cavour" loading="lazy" allowfullscreen="" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        <iframe src="https://www.google.com/maps?q=Piazza+Mercato,+Abbiategrasso&output=embed" title="Parcheggio Piazza Mercato" loading="lazy" allowfullscreen="" referrerpolicy="no-referrer-when-downgrade"></iframe>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- replace the parking links with embedded Google Maps iframes for each location
- add responsive grid styling to display the three maps in a single row on large screens

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e51e3f9ad883228e88dd79ee7ac6eb