### PR TITLE
Add local gallery and replace remote images

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
     @media(max-width:1100px){.map-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
     @media(max-width:700px){.map-grid{grid-template-columns:1fr}}
 
+    .gallery-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:24px;margin-top:36px}
+    .gallery-grid img{height:280px;width:100%;object-fit:cover;box-shadow:var(--shadow)}
+
     /* Subtle section divider like Squarespace */
     main > section:not(:first-child){border-top:1px solid var(--line)}
     main > section > h2{position:relative;padding-top:26px}
@@ -50,7 +53,7 @@
     header nav a:hover::after{width:100%}
 
     /* Hero */
-    .hero{min-height:90vh;display:grid;place-items:center;text-align:center;background:url('https://images.unsplash.com/photo-1529634892273-4f9cc89ff9a2?q=80&w=2000&auto=format&fit=crop') center/cover no-repeat;color:#fff;position:relative}
+    .hero{min-height:90vh;display:grid;place-items:center;text-align:center;background:url('assets/WhatsApp%20Image%202025-09-18%20at%2012.12.22%20(2).jpeg') center/cover no-repeat;color:#fff;position:relative}
     .hero::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.25)}
     .hero-content{position:relative;z-index:1}
     .hero .date{font-size:1.05rem;color:#f3f5f2;margin-top:.5rem}
@@ -102,11 +105,11 @@
           <p>Vi consigliamo di arrivare qualche minuto prima 😊</p>
         </div>
       </div>
-      <img src="A_2f010-00108_IMG-0000186280.jpg" alt="Basilica Santa Maria Nuova" class="warm-filter">
+      <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(1).jpeg" alt="Basilica Santa Maria Nuova" class="warm-filter">
     </section>
 
     <section id="ricevimento" class="row">
-      <img src="https://images.unsplash.com/photo-1511690656952-34342bb7c2f2?q=80&w=1600&auto=format&fit=crop" alt="Cascina Pietrasanta">
+      <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(3).jpeg" alt="Cascina Pietrasanta">
       <div>
         <h2>Ricevimento</h2>
         <div class="card">
@@ -138,7 +141,19 @@
           <p style="margin-top:10px">Intestatari: <strong>Susi & Tommi</strong><br><small>Causale: “Viaggio di nozze Susi e Tommi”</small></p>
         </div>
       </div>
-      <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1600&auto=format&fit=crop" alt="Viaggio di nozze">
+      <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(5).jpeg" alt="Viaggio di nozze">
+    </section>
+
+    <section id="ricordi">
+      <h2>Ricordi</h2>
+      <p class="lead">Alcuni scatti per entrare nell'atmosfera della giornata.</p>
+      <div class="gallery-grid">
+        <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.20.jpeg" alt="Coppia in primo piano" class="warm-filter">
+        <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(2).jpeg" alt="Dettaglio floreale" class="warm-filter">
+        <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(4).jpeg" alt="Momento di festa" class="warm-filter">
+        <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.22.jpeg" alt="Brindisi" class="warm-filter">
+        <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.22%20(1).jpeg" alt="Allestimento romantico" class="warm-filter">
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- use locally stored photos for the hero, ceremony, reception, and gift sections
- add a new “Ricordi” gallery section that showcases additional local images
- introduce supporting gallery styles for consistent layout and presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e8da1e3750832292ee57a4d78cc321