### PR TITLE
Remove header menu and relocate Ricordi slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,22 +35,36 @@
     @media(max-width:1100px){.map-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
     @media(max-width:700px){.map-grid{grid-template-columns:1fr}}
 
+    .slider{position:relative;margin-top:36px}
+    .slider-window{overflow:hidden;border-radius:var(--r-lg);box-shadow:var(--shadow)}
+    .slider-track{display:flex;transition:transform .45s ease;will-change:transform}
+    .slide{flex:0 0 100%;position:relative;margin:0}
+    .slide img{width:100%;height:420px;object-fit:cover;display:block}
+    .slider-control{position:absolute;top:50%;transform:translateY(-50%);border:none;background:rgba(255,255,255,.82);color:#2f343a;width:42px;height:42px;border-radius:50%;box-shadow:0 8px 18px rgba(31,35,40,.14);display:grid;place-items:center;font-size:1.5rem;font-family:inherit;cursor:pointer;transition:background .25s ease,transform .25s ease}
+    .slider-control:hover{background:#fff;transform:translateY(-50%) scale(1.04)}
+    .slider-control:disabled{opacity:.4;cursor:default;box-shadow:none}
+    .slider-control.prev{left:16px}
+    .slider-control.next{right:16px}
+    @media(max-width:700px){
+      .slide img{height:320px}
+      .slider-control{width:38px;height:38px;font-size:1.35rem}
+    }
+
+    .form-embed{margin-top:32px;border-radius:var(--r-lg);overflow:hidden;box-shadow:var(--shadow);border:1px solid var(--line);background:#fff}
+    .form-embed iframe{display:block;width:100%;height:1120px;border:0}
+    @media(max-width:700px){.form-embed iframe{height:1240px}}
+
     /* Subtle section divider like Squarespace */
     main > section:not(:first-child){border-top:1px solid var(--line)}
-    main > section > h2{position:relative;padding-top:26px}
-    main > section > h2::after{content:"";display:block;width:56px;height:2px;background:var(--accent);margin:.6rem 0 1rem}
-    @media(max-width:900px){main > section > h2::after{margin:.6rem auto 1rem}}
+    #ricordi{border-top:1px solid var(--line)}
+    main > section > h2,#ricordi h2{position:relative;padding-top:26px}
+    main > section > h2::after,#ricordi h2::after{content:"";display:block;width:56px;height:2px;background:var(--accent);margin:.6rem 0 1rem}
+    @media(max-width:900px){main > section > h2::after,#ricordi h2::after{margin:.6rem auto 1rem}}
 
-    /* Header */
-    header{position:fixed;inset:0 0 auto 0;height:70px;display:flex;align-items:center;justify-content:flex-end;padding:0 40px;background:transparent;transition:color .35s;z-index:10;color:#fff}
-    header.scrolled{color:#1f2328}
-    header nav{display:flex;gap:16px}
-    header nav a{color:inherit;font-weight:500;text-decoration:none;position:relative;padding:6px 2px}
-    header nav a::after{content:"";position:absolute;left:0;bottom:-4px;height:1.5px;width:0;background:currentColor;transition:width .25s ease}
-    header nav a:hover::after{width:100%}
+    #ricordi .slider{margin-top:36px}
 
     /* Hero */
-    .hero{min-height:90vh;display:grid;place-items:center;text-align:center;background:url('https://images.unsplash.com/photo-1529634892273-4f9cc89ff9a2?q=80&w=2000&auto=format&fit=crop') center/cover no-repeat;color:#fff;position:relative}
+    .hero{min-height:90vh;display:grid;place-items:center;text-align:center;background:url('assets/WhatsApp%20Image%202025-09-18%20at%2012.12.22%20(2).jpeg') center/cover no-repeat;color:#fff;position:relative}
     .hero::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.25)}
     .hero-content{position:relative;z-index:1}
     .hero .date{font-size:1.05rem;color:#f3f5f2;margin-top:.5rem}
@@ -76,15 +90,6 @@
   </style>
 </head>
 <body>
-  <header id="header">
-    <nav>
-      <a href="#cerimonia">Cerimonia</a>
-      <a href="#ricevimento">Ricevimento</a>
-      <a href="#parcheggi">Parcheggi</a>
-      <a href="#regalo">Regalo</a>
-    </nav>
-  </header>
-
   <section class="hero">
     <div class="hero-content">
       <h1>Susi & Tommi</h1>
@@ -102,11 +107,11 @@
           <p>Vi consigliamo di arrivare qualche minuto prima 😊</p>
         </div>
       </div>
-      <img src="A_2f010-00108_IMG-0000186280.jpg" alt="Basilica Santa Maria Nuova" class="warm-filter">
+      <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(1).jpeg" alt="Basilica Santa Maria Nuova" class="warm-filter">
     </section>
 
     <section id="ricevimento" class="row">
-      <img src="https://images.unsplash.com/photo-1511690656952-34342bb7c2f2?q=80&w=1600&auto=format&fit=crop" alt="Cascina Pietrasanta">
+      <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(3).jpeg" alt="Cascina Pietrasanta">
       <div>
         <h2>Ricevimento</h2>
         <div class="card">
@@ -132,15 +137,54 @@
       <div>
         <h2>Regalo</h2>
         <div class="card">
-          <p>Il vostro affetto è per noi il dono più grande. Se desiderate contribuire al nostro sogno, useremo il vostro pensiero per il <strong>viaggio di nozze</strong>.</p>
+          <p>Se volete farci un regalo, un contributo per il nostro viaggio di nozze:</p>
           <p><span class="pill">IBAN</span><br><strong id="iban">IT27H0310432380000000400112</strong></p>
           <button class="btn" id="copy">Copia IBAN</button>
           <p style="margin-top:10px">Intestatari: <strong>Susi & Tommi</strong><br><small>Causale: “Viaggio di nozze Susi e Tommi”</small></p>
         </div>
       </div>
-      <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1600&auto=format&fit=crop" alt="Viaggio di nozze">
+      <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(5).jpeg" alt="Viaggio di nozze">
     </section>
+
+    <section id="rsvp">
+      <h2>RSVP</h2>
+      <p class="lead">Confermate la vostra presenza compilando il modulo qui sotto. Ci aiuterà a organizzare al meglio la giornata.</p>
+      <div class="form-embed">
+        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScRLnLRfipXUzWAjpSJEHHha1O2i_3LIrIWUIe0bDjMalUGXA/viewform?embedded=true" title="Modulo di conferma presenze" loading="lazy">Caricamento…</iframe>
+      </div>
+    </section>
+
   </main>
+
+  <section id="ricordi">
+    <div class="container">
+      <h2>Ricordi</h2>
+      <p class="lead">Alcuni scatti per entrare nell'atmosfera della giornata.</p>
+      <div class="slider" data-slider>
+        <button class="slider-control prev" type="button" data-slider-prev aria-label="Foto precedente">&#10094;</button>
+        <div class="slider-window">
+          <div class="slider-track" data-slider-track>
+            <figure class="slide">
+              <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.20.jpeg" alt="Coppia in primo piano" class="warm-filter">
+            </figure>
+            <figure class="slide">
+              <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(2).jpeg" alt="Dettaglio floreale" class="warm-filter">
+            </figure>
+            <figure class="slide">
+              <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.21%20(4).jpeg" alt="Momento di festa" class="warm-filter">
+            </figure>
+            <figure class="slide">
+              <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.22.jpeg" alt="Brindisi" class="warm-filter">
+            </figure>
+            <figure class="slide">
+              <img src="assets/WhatsApp%20Image%202025-09-18%20at%2012.12.22%20(1).jpeg" alt="Allestimento romantico" class="warm-filter">
+            </figure>
+          </div>
+        </div>
+        <button class="slider-control next" type="button" data-slider-next aria-label="Foto successiva">&#10095;</button>
+      </div>
+    </div>
+  </section>
 
   <footer>
     <p>© 2026 Susi & Tommi — Grazie per condividere questo giorno con noi ♥</p>
@@ -152,11 +196,39 @@
       try{await navigator.clipboard.writeText(iban);alert('IBAN copiato!');}catch{alert('Copia non riuscita, seleziona e copia manualmente.');}
     });
 
-    // Cambia colore del testo header su scroll
-    const header=document.getElementById('header');
-    window.addEventListener('scroll',()=>{
-      if(window.scrollY>100){header.classList.add('scrolled');}
-      else{header.classList.remove('scrolled');}
+    // Slider sezione Ricordi
+    document.querySelectorAll('[data-slider]').forEach(slider=>{
+      const track=slider.querySelector('[data-slider-track]');
+      const prev=slider.querySelector('[data-slider-prev]');
+      const next=slider.querySelector('[data-slider-next]');
+      const slides=Array.from(track.children);
+      let index=0;
+
+      const update=()=>{
+        track.style.transform=`translateX(-${index*100}%)`;
+        if(prev) prev.disabled=index===0;
+        if(next) next.disabled=index===slides.length-1;
+      };
+
+      if(prev){
+        prev.addEventListener('click',()=>{
+          if(index>0){
+            index--;
+            update();
+          }
+        });
+      }
+
+      if(next){
+        next.addEventListener('click',()=>{
+          if(index<slides.length-1){
+            index++;
+            update();
+          }
+        });
+      }
+
+      update();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- remove the fixed header navigation so the menu no longer appears
- move the Ricordi slider section beneath the main content and keep its styling consistent with the other sections

## Testing
- not run (static page)

------
https://chatgpt.com/codex/tasks/task_b_68e8da1e3750832292ee57a4d78cc321